### PR TITLE
hotfix

### DIFF
--- a/src/main/java/by/piskunou/solvdlaba/service/impl/EmailServiceImpl.java
+++ b/src/main/java/by/piskunou/solvdlaba/service/impl/EmailServiceImpl.java
@@ -24,7 +24,7 @@ public class EmailServiceImpl implements EmailService {
     private final FreeMarkerConfigurer freemarkerConfigurer;
     private final JavaMailSender emailSender;
 
-    @Value("${MAIN_HOST}")
+    @Value("${AUTH_HOST}")
     private String host;
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,4 +18,4 @@ spring:
             enable: true
   #Kafka
   kafka:
-    bootstrap-servers: ${MAIN_HOST}:9092
+    bootstrap-servers: ${KAFKA_HOST}:9092

--- a/src/main/resources/templates/mail.ftl
+++ b/src/main/resources/templates/mail.ftl
@@ -9,6 +9,6 @@
     <p>Someone, hopefully you, has requested to reset the password for your Airport account on http://${host}:8765</p>
     <p>If you did not perform this request, you can safely ignore this email. </p>
     <p>Otherwise, click the link below to complete the process.</p>
-    <a href="http://${host}:8765/password/edit?reset_password_token=${token}" rel="link">Reset password</a>
+    <a href="http://${host}:8080/password/edit?reset_password_token=${token}" rel="link">Reset password</a>
 </body>
 </html>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Kafka server and changing the email reset password link. 

### Detailed summary
- Updated `bootstrap-servers` in `application.yaml` from `${MAIN_HOST}:9092` to `${KAFKA_HOST}:9092`
- Changed `host` value in `EmailServiceImpl.java` from `${MAIN_HOST}` to `${AUTH_HOST}`
- Updated reset password link in `mail.ftl` from `http://${host}:8765/password/edit?reset_password_token=${token}` to `http://${host}:8080/password/edit?reset_password_token=${token}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->