### PR TITLE
configure k8s CI step for self-hosted

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,3 +36,17 @@ jobs:
           target: production
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  deployment:
+    needs: build
+    runs-on:
+      - self-hosted
+      - mail-service-k8s
+    steps:
+      - name: Rollout restart
+        run: |
+          set -ex
+          cd $HOME
+          wget https://dl.k8s.io/release/v1.26.0/bin/linux/arm64/kubectl
+          chmod +x ./kubectl
+          ~/kubectl rollout restart deployment mail-service-v1 -n default


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a deployment step to the Docker workflow that restarts the mail-service-v1 deployment in the default namespace using kubectl.

### Detailed summary:
- Added deployment step to Docker workflow
- Deployment step restarts mail-service-v1 deployment using kubectl in the default namespace

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->